### PR TITLE
Fix test bug on Windows

### DIFF
--- a/src/test/java/com/yasuenag/hwrand/it/JNIIT.java
+++ b/src/test/java/com/yasuenag/hwrand/it/JNIIT.java
@@ -10,7 +10,9 @@ import com.yasuenag.hwrand.x86.HWRandX86Provider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.function.Executable;
 
@@ -66,6 +68,7 @@ public class JNIIT extends TestBase{
 
   @Test
   @EnabledOnOs(OS.WINDOWS)
+  @EnabledForJreRange(max = JRE.JAVA_21)
   public void testOnWindows(){
     Assertions.assertThrows(RuntimeException.class, new ExceptionAtAddProvider());
   }


### PR DESCRIPTION
I saw folloging error on GHA on windows-latest runner:

```
[INFO] Running com.yasuenag.hwrand.it.JNIIT
Error:  Tests run: 3, Failures: 1, Errors: 0, Skipped: 2, Time elapsed: 0.055 s <<< FAILURE! -- in com.yasuenag.hwrand.it.JNIIT
Error:  com.yasuenag.hwrand.it.JNIIT.testOnWindows -- Time elapsed: 0.022 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected java.lang.RuntimeException to be thrown, but nothing was thrown.
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:73)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3128)
	at com.yasuenag.hwrand.it.JNIIT.testOnWindows(JNIIT.java:70)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
```